### PR TITLE
not setting query to null, preventing NPE

### DIFF
--- a/src/net/thegreshams/firebase4j/service/Firebase.java
+++ b/src/net/thegreshams/firebase4j/service/Firebase.java
@@ -619,7 +619,7 @@ public class Firebase {
 		response = new FirebaseResponse( success, code, body, writer.toString() );
 		
 		//clear the query
-		query = null;
+		query.clear(); // query is only initialized in the constructor. 
 		
 		return response;
 	}


### PR DESCRIPTION
addQuery has no check that query exists before using it.